### PR TITLE
Update library.properties url to reflect repo name change

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,6 +5,6 @@ maintainer=Arduino <info@arduino.cc>
 sentence=Firmware for the Physics Lab kit.
 paragraph=This library depends on the ArduinoBLE and MKRIMU libraries.
 category=Communication
-url=https://github.com/arduino/PhysicsLabsFirmware
+url=https://github.com/arduino/PhysicsLabFirmware
 architectures=samd
 includes=PhysicsLabFirmware.h


### PR DESCRIPTION
The repository has been renamed from PhysicsLabsFirmware to PhysicsLabFirmware so the library.properties url value must be updated as well.

Fixes https://github.com/bcmi-labs/PhysicsLabFirmware/issues/3