### PR TITLE
Use internal LSM9DS1 IMU driver

### DIFF
--- a/examples/PhysicsLabFirmware/INA226.cpp
+++ b/examples/PhysicsLabFirmware/INA226.cpp
@@ -25,7 +25,7 @@
 
 INA226Class::INA226Class(TwoWire& wire) :
   _wire(&wire)
-{  
+{
 }
 
 INA226Class::~INA226Class()
@@ -41,10 +41,10 @@ int INA226Class::begin(uint8_t address, float shuntResistance)
 
   _wire->begin();
 
-  // force 
+  // force
   if (!writeRegister(INA226_CALIBRATION_REG, calibration)) {
     end();
-    
+
     return 0;
   }
 
@@ -63,7 +63,7 @@ float INA226Class::readCurrent()
   if (value == NAN) {
     return -1;
   }
-  
+
   return (((int16_t)value) / 1000.0);
 }
 

--- a/examples/PhysicsLabFirmware/INA226.h
+++ b/examples/PhysicsLabFirmware/INA226.h
@@ -24,23 +24,23 @@
 #include <Wire.h>
 
 class INA226Class {
-public:
-  INA226Class(TwoWire& wire);
-  virtual ~INA226Class();
+  public:
+    INA226Class(TwoWire& wire);
+    virtual ~INA226Class();
 
-  int begin(uint8_t address, float shuntResistance = 0.0002);
-  void end();
+    int begin(uint8_t address, float shuntResistance = 0.0002);
+    void end();
 
-  float readCurrent();
-  float readBusVoltage();
+    float readCurrent();
+    float readBusVoltage();
 
-private:
-  long readRegister(uint8_t address);
-  int writeRegister(uint8_t address, uint16_t value);
+  private:
+    long readRegister(uint8_t address);
+    int writeRegister(uint8_t address, uint16_t value);
 
-private:
-  TwoWire* _wire;
-  uint8_t _i2cAddress;
+  private:
+    TwoWire* _wire;
+    uint8_t _i2cAddress;
 };
 
 extern INA226Class INA226;

--- a/examples/PhysicsLabFirmware/LSM9DS1.cpp
+++ b/examples/PhysicsLabFirmware/LSM9DS1.cpp
@@ -1,0 +1,236 @@
+/*
+  This file is part of the PhysicsLabFirmware library.
+  Copyright (c) 2019 Arduino SA. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "LSM9DS1.h"
+
+#define LSM9DS1_ADDRESS            0x6b
+
+#define LSM9DS1_WHO_AM_I           0x0f
+#define LSM9DS1_CTRL_REG1_G        0x10
+#define LSM9DS1_STATUS_REG         0x17
+#define LSM9DS1_OUT_X_G            0x18
+#define LSM9DS1_CTRL_REG6_XL       0x20
+#define LSM9DS1_CTRL_REG8          0x22
+#define LSM9DS1_OUT_X_XL           0x28
+
+// magnetometer
+#define LSM9DS1_ADDRESS_M          0x1e
+
+#define LSM9DS1_CTRL_REG1_M        0x20
+#define LSM9DS1_CTRL_REG2_M        0x21
+#define LSM9DS1_CTRL_REG3_M        0x22
+#define LSM9DS1_STATUS_REG_M       0x27
+#define LSM9DS1_OUT_X_L_M          0x28
+
+LSM9DS1Class::LSM9DS1Class(TwoWire& wire) :
+  _wire(&wire)
+{
+}
+
+LSM9DS1Class::~LSM9DS1Class()
+{
+}
+
+int LSM9DS1Class::begin()
+{
+  _wire->begin();
+
+  // reset
+  writeRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG8, 0x05);
+  writeRegister(LSM9DS1_ADDRESS_M, LSM9DS1_CTRL_REG2_M, 0x0c);
+
+  delay(10);
+
+  if (readRegister(LSM9DS1_ADDRESS, LSM9DS1_WHO_AM_I) != 0x68) {
+    end();
+
+    return 0;
+  }
+
+  if (readRegister(LSM9DS1_ADDRESS_M, LSM9DS1_WHO_AM_I) != 0x3d) {
+    end();
+
+    return 0;
+  }
+
+  writeRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG1_G, 0x58); // 59.5 Hz, 2000 dps, 16 Hz BW
+  writeRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG6_XL, 0x50); // 50 Hz, 4G
+
+  writeRegister(LSM9DS1_ADDRESS_M, LSM9DS1_CTRL_REG1_M, 0xb4); // Temperature compensation enable, medium performance, 20 Hz
+  writeRegister(LSM9DS1_ADDRESS_M, LSM9DS1_CTRL_REG2_M, 0x00); // 4 Gauss
+  writeRegister(LSM9DS1_ADDRESS_M, LSM9DS1_CTRL_REG3_M, 0x00); // Continuous conversion mode
+
+  return 1;
+}
+
+void LSM9DS1Class::end()
+{
+  writeRegister(LSM9DS1_ADDRESS_M, LSM9DS1_CTRL_REG3_M, 0x03);
+  writeRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG1_G, 0x00);
+  writeRegister(LSM9DS1_ADDRESS, LSM9DS1_CTRL_REG6_XL, 0x00);
+
+  _wire->end();
+}
+
+int LSM9DS1Class::readAcceleration(float& x, float& y, float& z)
+{
+  int16_t data[3];
+
+  if (!readRegisters(LSM9DS1_ADDRESS, LSM9DS1_OUT_X_XL, (uint8_t*)data, sizeof(data))) {
+    x = NAN;
+    y = NAN;
+    z = NAN;
+
+    return 0;
+  }
+
+  x = data[0] * 4.0 / 32768.0;
+  y = data[1] * 4.0 / 32768.0;
+  z = data[2] * 4.0 / 32768.0;
+
+  return 1;
+}
+
+int LSM9DS1Class::accelerationAvailable()
+{
+  if (readRegister(LSM9DS1_ADDRESS, LSM9DS1_STATUS_REG) & 0x01) {
+    return 1;
+  }
+
+  return 0;
+}
+
+float LSM9DS1Class::accelerationSampleRate()
+{
+  return 50.0;
+}
+
+int LSM9DS1Class::readGyroscope(float& x, float& y, float& z)
+{
+  int16_t data[3];
+
+  if (!readRegisters(LSM9DS1_ADDRESS, LSM9DS1_OUT_X_G, (uint8_t*)data, sizeof(data))) {
+    x = NAN;
+    y = NAN;
+    z = NAN;
+
+    return 0;
+  }
+
+  x = data[0] * 2000.0 / 32768.0;
+  y = data[1] * 2000.0 / 32768.0;
+  z = data[2] * 2000.0 / 32768.0;
+
+  return 1;
+}
+
+int LSM9DS1Class::gyroscopeAvailable()
+{
+  if (readRegister(LSM9DS1_ADDRESS, LSM9DS1_STATUS_REG) & 0x02) {
+    return 1;
+  }
+
+  return 0;
+}
+
+float LSM9DS1Class::gyroscopeSampleRate()
+{
+  return 59.5;
+}
+
+int LSM9DS1Class::readMagneticField(float& x, float& y, float& z)
+{
+  int16_t data[3];
+
+  if (!readRegisters(LSM9DS1_ADDRESS_M, LSM9DS1_OUT_X_L_M, (uint8_t*)data, sizeof(data))) {
+    x = NAN;
+    y = NAN;
+    z = NAN;
+
+    return 0;
+  }
+
+  x = data[0] * 4.0  * 100.0 / 32768.0;
+  y = data[1] * 4.0  * 100.0 / 32768.0;
+  z = data[2] * 4.0  * 100.0 / 32768.0;
+
+  return 1;
+}
+
+int LSM9DS1Class::magneticFieldAvailable()
+{
+  if (readRegister(LSM9DS1_ADDRESS_M, LSM9DS1_STATUS_REG_M) & 0x08) {
+    return 1;
+  }
+
+  return 0;
+}
+
+float LSM9DS1Class::magneticFieldSampleRate()
+{
+  return 20.0;
+}
+
+int LSM9DS1Class::readRegister(uint8_t slaveAddress, uint8_t address)
+{
+  _wire->beginTransmission(slaveAddress);
+  _wire->write(address);
+  if (_wire->endTransmission() != 0) {
+    return -1;
+  }
+
+  if (_wire->requestFrom(slaveAddress, 1) != 1) {
+    return -1;
+  }
+
+  return _wire->read();
+}
+
+int LSM9DS1Class::readRegisters(uint8_t slaveAddress, uint8_t address, uint8_t* data, size_t length)
+{
+  _wire->beginTransmission(slaveAddress);
+  _wire->write(0x80 | address);
+  if (_wire->endTransmission(false) != 0) {
+    return -1;
+  }
+
+  if (_wire->requestFrom(slaveAddress, length) != length) {
+    return 0;
+  }
+
+  for (size_t i = 0; i < length; i++) {
+    *data++ = _wire->read();
+  }
+
+  return 1;
+}
+
+int LSM9DS1Class::writeRegister(uint8_t slaveAddress, uint8_t address, uint8_t value)
+{
+  _wire->beginTransmission(slaveAddress);
+  _wire->write(address);
+  _wire->write(value);
+  if (_wire->endTransmission() != 0) {
+    return 0;
+  }
+
+  return 1;
+}
+
+LSM9DS1Class IMU(Wire);

--- a/examples/PhysicsLabFirmware/LSM9DS1.h
+++ b/examples/PhysicsLabFirmware/LSM9DS1.h
@@ -1,0 +1,60 @@
+/*
+  This file is part of the PhysicsLabFirmware library.
+  Copyright (c) 2019 Arduino SA. All rights reserved.
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _LSM9DS1_H_
+#define _LSM9DS1_H_
+
+#include <Arduino.h>
+#include <Wire.h>
+
+class LSM9DS1Class {
+  public:
+    LSM9DS1Class(TwoWire& wire);
+    virtual ~LSM9DS1Class();
+
+    int begin();
+    void end();
+
+    // Accelerometer
+    virtual int readAcceleration(float& x, float& y, float& z); // Results are in G (earth gravity).
+    virtual int accelerationAvailable(); // Number of samples in the FIFO.
+    virtual float accelerationSampleRate(); // Sampling rate of the sensor.
+
+    // Gyroscope
+    virtual int readGyroscope(float& x, float& y, float& z); // Results are in degrees/second.
+    virtual int gyroscopeAvailable(); // Number of samples in the FIFO.
+    virtual float gyroscopeSampleRate(); // Sampling rate of the sensor.
+
+    // Magnetometer
+    virtual int readMagneticField(float& x, float& y, float& z); // Results are in uT (micro Tesla).
+    virtual int magneticFieldAvailable(); // Number of samples in the FIFO.
+    virtual float magneticFieldSampleRate(); // Sampling rate of the sensor.
+
+  private:
+    int readRegister(uint8_t slaveAddress, uint8_t address);
+    int readRegisters(uint8_t slaveAddress, uint8_t address, uint8_t* data, size_t length);
+    int writeRegister(uint8_t slaveAddress, uint8_t address, uint8_t value);
+
+  private:
+    TwoWire* _wire;
+};
+
+extern LSM9DS1Class IMU;
+
+#endif

--- a/extras/BLE_spec.txt
+++ b/extras/BLE_spec.txt
@@ -114,7 +114,7 @@ UUID:       555a0001-5001-467a-9538-01f0652c74e8
 Properties: notify
 Value size: 12 bytes
 Data format: Array of 3 x 32-bit IEEE floats (little endian)
-Description: X, Y, Z acceleration values in G's, if subscribed notification sent every 10 ms
+Description: X, Y, Z acceleration values in G's, if subscribed notification sent at 50 Hz
 
 Gyroscope Characteristic
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -123,7 +123,7 @@ UUID:       555a0001-5002-467a-9538-01f0652c74e8
 Properties: notify
 Value size: 12 bytes
 Data format: Array of 3 x 32-bit IEEE floats (little endian)
-Description: X, Y, Z gyroscope values in degrees per second, if subscribed notification sent every 10 ms
+Description: X, Y, Z gyroscope values in degrees per second, if subscribed notification sent at 59.5 Hz
 
 Magnetic Field Characteristic
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -132,4 +132,4 @@ UUID:       555a0001-5003-467a-9538-01f0652c74e8
 Properties: notify
 Value size: 12 bytes
 Data format: Array of 3 x 32-bit IEEE floats (little endian)
-Description: X, Y, Z magnetic fields values in uT, if subscribed notification sent every 10 ms
+Description: X, Y, Z magnetic fields values in Gauss, if subscribed notification sent at 20 Hz


### PR DESCRIPTION
These changes add an internal driver for the LSM9DS1 IMU with the same API of the MKRIMU lib.

The IMU is configured with the following parameters:
- Accelerometer - 4G range, 50 Hz
- Gyroscope - 2000 dps range, 59.5 Hz
- Magnetometer - 4 Gauss range, 20 Hz

Now the status registers are queried to check if new data is available, instead of previously using millis() and a fixed interval.