### PR TITLE
Add notification if VDDIO is too low

### DIFF
--- a/examples/PhysicsLabFirmware/MeasureInternalVoltage.ino
+++ b/examples/PhysicsLabFirmware/MeasureInternalVoltage.ino
@@ -47,7 +47,7 @@ static uint32_t analogReadMux(uint32_t muxpos)
   // Clear the Data Ready flag
   ADC->INTFLAG.reg = ADC_INTFLAG_RESRDY;
 
-  // Start conversion again, since The first conversion after the reference is changed must not be used.
+  // Start conversion again, since the first conversion after the reference is changed must not be used.
   syncADC();
   ADC->SWTRIG.bit.START = 1;
 

--- a/examples/PhysicsLabFirmware/MeasureInternalVoltage.ino
+++ b/examples/PhysicsLabFirmware/MeasureInternalVoltage.ino
@@ -1,0 +1,70 @@
+/*
+ * 0x18 TEMP Temperature reference
+ * 0x19 BANDGAP Bandgap voltage
+ * 0x1A SCALEDCOREVCC 1/4 scaled core supply
+ * 0x1B SCALEDIOVCC 1/4 scaled I/O supply
+ */
+
+
+// Wait for synchronization of registers between the clock domains
+static __inline__ void syncADC() __attribute__((always_inline, unused));
+static void syncADC() {
+  while (ADC->STATUS.bit.SYNCBUSY == 1)
+    ;
+}
+
+static uint32_t analogReadMux(uint32_t muxpos)
+{
+  syncADC();
+  ADC->INPUTCTRL.bit.MUXPOS = muxpos; // Selection for the positive ADC input
+
+  // Control A
+  /*
+   * Bit 1 ENABLE: Enable
+   *   0: The ADC is disabled.
+   *   1: The ADC is enabled.
+   * Due to synchronization, there is a delay from writing CTRLA.ENABLE until the peripheral is enabled/disabled. The
+   * value written to CTRL.ENABLE will read back immediately and the Synchronization Busy bit in the Status register
+   * (STATUS.SYNCBUSY) will be set. STATUS.SYNCBUSY will be cleared when the operation is complete.
+   *
+   * Before enabling the ADC, the asynchronous clock source must be selected and enabled, and the ADC reference must be
+   * configured. The first conversion after the reference is changed must not be used.
+   */
+  syncADC();
+  ADC->CTRLA.bit.ENABLE = 0x01;             // Enable ADC
+
+  // Start conversion
+  syncADC();
+  ADC->SWTRIG.bit.START = 1;
+
+  // Clear the Data Ready flag
+  ADC->INTFLAG.reg = ADC_INTFLAG_RESRDY;
+
+  // Start conversion again, since The first conversion after the reference is changed must not be used.
+  syncADC();
+  ADC->SWTRIG.bit.START = 1;
+
+  // Store the value
+  while (ADC->INTFLAG.bit.RESRDY == 0);   // Waiting for conversion to complete
+  uint32_t valueRead = ADC->RESULT.reg;
+
+  syncADC();
+  ADC->CTRLA.bit.ENABLE = 0x00;             // Disable ADC
+  syncADC();
+
+  return valueRead;
+}
+
+float getIoVcc() {
+  analogReference(AR_INTERNAL1V0);
+  float result = analogReadMux(0x1B) * 4 / 1024.0f;
+  analogReference(AR_DEFAULT);
+  return result;
+}
+
+float getCoreVcc() {
+  analogReference(AR_INTERNAL1V0);
+  float result = analogReadMux(0x1A) * 4 / 1024.0f;
+  analogReference(AR_DEFAULT);
+  return result;
+}

--- a/examples/PhysicsLabFirmware/MeasureInternalVoltage.ino
+++ b/examples/PhysicsLabFirmware/MeasureInternalVoltage.ino
@@ -5,6 +5,13 @@
  * 0x1B SCALEDIOVCC 1/4 scaled I/O supply
  */
 
+/*
+ * GATT specifications:
+ * Battery Level org.bluetooth.characteristic.battery_level  0x2A19  GSS
+ * Battery Level State org.bluetooth.characteristic.battery_level_state  0x2A1B  GSS
+ * Battery Power State org.bluetooth.characteristic.battery_power_state  0x2A1A  GSS
+ */
+
 
 // Wait for synchronization of registers between the clock domains
 static __inline__ void syncADC() __attribute__((always_inline, unused));

--- a/examples/PhysicsLabFirmware/PhysicsLabFirmware.ino
+++ b/examples/PhysicsLabFirmware/PhysicsLabFirmware.ino
@@ -59,6 +59,8 @@ unsigned long imuTime;
 
 #define IMU_UPDATE_TIME 50
 
+#define GSK_VERSION    2
+
 //#define DEBUG //uncomment to debug the code :)
 
 Adafruit_LSM9DS1 imu = Adafruit_LSM9DS1();
@@ -134,6 +136,7 @@ void setup() {
 
   BLE.advertise();
   imuTime = millis();
+  versionCharacteristic.writeValue(GSK_VERSION);
 }
 
 void loop() {

--- a/examples/PhysicsLabFirmware/PhysicsLabFirmware.ino
+++ b/examples/PhysicsLabFirmware/PhysicsLabFirmware.ino
@@ -64,8 +64,8 @@ unsigned long imuTime;
 
 #define GSK_VERSION    2
 
-#define MINIMUM_WORKING_CORE_VOLTAGE    3.0f
-#define NORMAL_WORKING_CORE_VOLTAGE     3.3f
+#define MINIMUM_WORKING_CORE_VOLTAGE    3.10f
+#define NORMAL_WORKING_CORE_VOLTAGE     3.30f
 
 //#define DEBUG //uncomment to debug the code :)
 
@@ -87,6 +87,16 @@ void setup() {
   pinMode(RESISTANCE_AUX_PIN, OUTPUT);
 
   digitalWrite(RESISTANCE_AUX_PIN, LOW);
+
+  if (getIoVcc() < MINIMUM_WORKING_CORE_VOLTAGE) {
+    pinMode(LED_BUILTIN, OUTPUT);
+    while (1) {
+      digitalWrite(LED_BUILTIN, HIGH);
+      delay(50);
+      digitalWrite(LED_BUILTIN, LOW);
+      delay(50);
+    }
+  }
 
   if (!INA226.begin(0x45)) {
     Serial.println("Failed to initialized INA226!");

--- a/examples/PhysicsLabFirmware/PhysicsLabFirmware.ino
+++ b/examples/PhysicsLabFirmware/PhysicsLabFirmware.ino
@@ -61,6 +61,8 @@ unsigned long imuTime;
 
 #define GSK_VERSION    2
 
+#define MINIMUM_WORKING_CORE_VOLTAGE    3.0f
+
 //#define DEBUG //uncomment to debug the code :)
 
 Adafruit_LSM9DS1 imu = Adafruit_LSM9DS1();
@@ -139,8 +141,23 @@ void setup() {
   versionCharacteristic.writeValue(GSK_VERSION);
 }
 
+long lastVccMeasure = 0;
+
 void loop() {
   lastNotify = 0;
+
+  if (millis() - lastVccMeasure > 5000) {
+    if (getIoVcc() < MINIMUM_WORKING_CORE_VOLTAGE) {
+      pinMode(LED_BUILTIN, OUTPUT);
+      for (int i = 0; i < 10; i++) {
+        digitalWrite(LED_BUILTIN, HIGH);
+        delay(50);
+        digitalWrite(LED_BUILTIN, LOW);
+        delay(50);
+      }
+    }
+    lastVccMeasure = millis();
+  }
 
   while (BLE.connected()) {
     if (ledCharacteristic.written()) {

--- a/examples/PhysicsLabFirmware/PhysicsLabFirmware.ino
+++ b/examples/PhysicsLabFirmware/PhysicsLabFirmware.ino
@@ -83,13 +83,13 @@ void setup() {
   digitalWrite(RESISTANCE_AUX_PIN, LOW);
 
   if (!INA226.begin(0x45)) {
-    Serial.println("Failled to initialized INA226!");
+    Serial.println("Failed to initialized INA226!");
 
     while (1);
   }
 
   if (!imu.begin()) {
-    Serial.println("Failled to initialized IMU!");
+    Serial.println("Failed to initialized IMU!");
 
     while (1);
   }
@@ -99,7 +99,7 @@ void setup() {
   imu.setupGyro(imu.LSM9DS1_GYROSCALE_245DPS);
 
   if (!BLE.begin()) {
-    Serial.println("Failled to initialized BLE!");
+    Serial.println("Failed to initialized BLE!");
 
     while (1);
   }


### PR DESCRIPTION
This PR adds two notification methods to signal that VDDIO is too low (which normally means that the battery is very discharged).

Method one:
- every 5 seconds check `SCALEDIOVCC` using internal bandgap as reference, then rever tto normal VREF. If the voltage is too low, quickly blink for 10 times `LED_BUILTIN`

Method two (experimental):
- add a batteryLevel notification (standard GATT profile). This should allow automatic notifications if the voltage is too low. On nRF Connect app I can't read this property but maybe I'm missing something.

