### PR TITLE
Added note for archiving purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PhysicsLabFirmware library for Arduino
 
+**Note:** This library has been superseded by [arduino-libraries/Arduino_ScienceJournal](https://github.com/arduino-libraries/Arduino_ScienceJournal).
+
 [![Check Arduino status](https://github.com/arduino-libraries/PhysicsLabFirmware/actions/workflows/check-arduino.yml/badge.svg)](https://github.com/arduino-libraries/PhysicsLabFirmware/actions/workflows/check-arduino.yml)
 [![Compile Examples status](https://github.com/arduino-libraries/PhysicsLabFirmware/actions/workflows/compile-examples.yml/badge.svg)](https://github.com/arduino-libraries/PhysicsLabFirmware/actions/workflows/compile-examples.yml)
 [![Spell Check status](https://github.com/arduino-libraries/PhysicsLabFirmware/actions/workflows/spell-check.yml/badge.svg)](https://github.com/arduino-libraries/PhysicsLabFirmware/actions/workflows/spell-check.yml)


### PR DESCRIPTION
I added a note as discussed in the https://github.com/arduino-libraries/PhysicsLabFirmware/pull/16 . This repo should be archived as it has been superseded by the Arduino Science Journal library

cc @cmaglie @VKin-Arduino @per1234 